### PR TITLE
chore(deps): bump .NET packages (patch/minor)

### DIFF
--- a/IdeaStudio.Website.Tests/IdeaStudio.Website.Tests.csproj
+++ b/IdeaStudio.Website.Tests/IdeaStudio.Website.Tests.csproj
@@ -10,13 +10,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Markdig" Version="1.1.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+		<PackageReference Include="Markdig" Version="1.3.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -30,12 +30,10 @@
 
 	<Target Name="CopyDepsFiles" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
 		<ItemGroup>
-			<DepsFilePaths
-				Include="$([System.IO.Path]::ChangeExtension('%(_ResolvedProjectReferencePaths.FullPath)', '.deps.json'))" />
+			<DepsFilePaths Include="$([System.IO.Path]::ChangeExtension('%(_ResolvedProjectReferencePaths.FullPath)', '.deps.json'))" />
 		</ItemGroup>
 
-		<Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutputPath)"
-			Condition="Exists('%(DepsFilePaths.FullPath)')" />
+		<Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutputPath)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
 	</Target>
 
 </Project>

--- a/IdeaStudio.Website/IdeaStudio.Website.csproj
+++ b/IdeaStudio.Website/IdeaStudio.Website.csproj
@@ -14,13 +14,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="markdig" Version="1.1.3" />
-        <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer"
-            Version="10.0.7" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.7" />
+        <PackageReference Include="markdig" Version="1.3.2" />
+        <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.9" />
     </ItemGroup>
 
     <Target Name="NpmInstall" Inputs="package.json" Outputs="node_modules/.install-stamp">
@@ -28,11 +27,7 @@
         <Exec Command="npm install" Condition="'$(RestorePackagesWithLockFile)' != 'true'" />
         <Touch Files="node_modules/.install-stamp" AlwaysCreate="true" />
     </Target>
-    <Target Name="NpmRunBuild"
-            DependsOnTargets="NpmInstall"
-            BeforeTargets="BeforeBuild"
-            Inputs="package.json;package-lock.json;$(MSBuildProjectDirectory)/wwwroot/scss/**/*.scss;$(MSBuildProjectDirectory)/wwwroot/src/**/*.js"
-            Outputs="$(MSBuildProjectDirectory)/wwwroot/css/styles.min.css;$(MSBuildProjectDirectory)/wwwroot/js/cinema.bundle.js">
+    <Target Name="NpmRunBuild" DependsOnTargets="NpmInstall" BeforeTargets="BeforeBuild" Inputs="package.json;package-lock.json;$(MSBuildProjectDirectory)/wwwroot/scss/**/*.scss;$(MSBuildProjectDirectory)/wwwroot/src/**/*.js" Outputs="$(MSBuildProjectDirectory)/wwwroot/css/styles.min.css;$(MSBuildProjectDirectory)/wwwroot/js/cinema.bundle.js">
         <Exec Command="npm run build" />
     </Target>
 


### PR DESCRIPTION
Bumps .NET packages to latest patch/minor (no majors):

**Website** — AspNetCore.Components.WebAssembly(.DevServer) 10.0.7→10.0.9, Extensions.Http/.Localization 10.0.7→10.0.9, ApplicationInsights.WorkerService 3.1.0→3.1.2, Markdig 1.1.3→1.3.2.
**Tests** — Markdig 1.3.2 (in sync), Mvc.Testing 10.0.7→10.0.9, NET.Test.Sdk 18.5.0→18.7.0, coverlet.collector 10.0.0→10.0.1.

167 tests green; clean restore+build. npm dev-dep patches (sass/fontsource) deferred — local install failed and they don't change shipped output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)