### PR TITLE
fix(security): npm --ignore-scripts (clears SonarCloud quality gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
       # must be present before the dotnet build.
       - name: Install asset-pipeline deps
         working-directory: IdeaStudio.Website
-        run: npm ci
+        # --ignore-scripts: no dep needs lifecycle scripts (esbuild ships its
+        # binary via optionalDependencies), and it blocks supply-chain script
+        # execution at install time (Sonar shell:S6505).
+        run: npm ci --ignore-scripts
 
       - name: Build (Debug)
         run: dotnet build IdeaStudio.sln -c Debug

--- a/scripts/netlify-build.sh
+++ b/scripts/netlify-build.sh
@@ -36,9 +36,9 @@ dotnet publish "${PROJECT}" -c Release -o "${PUBLISH_DIR}"
 # auto-installed before esbuild bundles them, so install explicitly here.
 echo "→ npm ci in ${FUNCTIONS_DIR} (puppeteer-core, @sparticuz/chromium-min, …)"
 if [ -f "${FUNCTIONS_DIR}/package-lock.json" ]; then
-  npm --prefix "${FUNCTIONS_DIR}" ci
+  npm --prefix "${FUNCTIONS_DIR}" ci --ignore-scripts
 else
-  npm --prefix "${FUNCTIONS_DIR}" install
+  npm --prefix "${FUNCTIONS_DIR}" install --ignore-scripts
 fi
 
 # Prerender each route to static HTML (real content + per-page <head> for crawlers


### PR DESCRIPTION
Fixes the only failing SonarCloud condition (`new_security_rating` = C): two `shell:S6505` findings where `npm ci`/`install` ran without `--ignore-scripts` (lifecycle scripts can execute at install = supply-chain risk). Adds `--ignore-scripts` to the Netlify functions install and the CI website install. Safe — no dep needs lifecycle scripts (esbuild uses optionalDependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)