### PR TITLE
fix(sonar): clear last two S3923 reliability bugs

### DIFF
--- a/.agents/skills/remotion/examples/WalkthroughComposition.tsx
+++ b/.agents/skills/remotion/examples/WalkthroughComposition.tsx
@@ -23,13 +23,9 @@ export const WalkthroughComposition: React.FC = () => {
       {screensManifest.screens.map((screen, index) => {
         const durationInFrames = screen.duration * fps;
         
-        // Select transition based on screen config
-        const transition =
-          screen.transitionType === 'slide'
-            ? slide()
-            : screen.transitionType === 'zoom'
-            ? fade() // Can customize with zoom effect
-            : fade();
+        // Select transition based on screen config.
+        // 'zoom' currently falls back to fade() — customize with a zoom effect later.
+        const transition = screen.transitionType === 'slide' ? slide() : fade();
 
         return (
           <TransitionSeries.Sequence

--- a/IdeaStudio.Website/wwwroot/index.html
+++ b/IdeaStudio.Website/wwwroot/index.html
@@ -25,19 +25,13 @@
     <meta name="twitter:description" content="Andrés Talavera — Consultant .NET & Azure, techlead, formateur. Lyon et à distance." />
     <meta name="twitter:image" content="https://ideastud.io/images/andres-talavera.jpeg" />
 
-    <!-- Base href. On localhost we always use `/`. Otherwise we respect the
-         first path segment so Blazor routes resolve under /fr or /en prefixes. -->
+    <!-- Base href. Every host we target (localhost, Netlify, static hosts)
+         resolves Blazor routes from the root, so the base is always `/`. -->
     <base />
     <script>
         (function () {
             var base = document.getElementsByTagName('base')[0];
-            var host = window.location.host;
-            if (host.indexOf('localhost') !== -1 || host.indexOf('127.0.0.1') !== -1) {
-                base.setAttribute('href', '/');
-            } else {
-                // Static hosts (Azure SWA, GitHub Pages) — always resolve from root.
-                base.setAttribute('href', '/');
-            }
+            base.setAttribute('href', '/');
         })();
     </script>
 


### PR DESCRIPTION
Final two `S3923` reliability bugs that kept `new_reliability_rating` at C on main.

- **index.html** — base-href `if/else` set the same `'/'` in both branches; collapsed to one unconditional set.
- **WalkthroughComposition.tsx** (vendored remotion example) — nested transition ternary returned `fade()` for both `'zoom'` and the default; collapsed to slide-or-fade.

No behavior change. Brings `new_reliability_rating` to A → green main gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)