### PR TITLE
fix: EN trainer content-loss + a11y/nav-state gaps (audit Wave 1)

### DIFF
--- a/IdeaStudio.Website.Tests/JsonContentGatewayTests.cs
+++ b/IdeaStudio.Website.Tests/JsonContentGatewayTests.cs
@@ -159,16 +159,21 @@ public class JsonContentGatewayTests
         Assert.Contains(en!, s => s.Slug == "ai-enterprise");
     }
 
-    [Fact]
-    public void TrainingsJson_AllModulesUseValidCategory()
+    // Guards the EN "AI" content-loss bug: TrainingCatalogue groups by TrainingCategories.Ordered,
+    // so every category present in the data MUST appear in that ordered list for the culture, in
+    // BOTH languages — otherwise the whole family is silently dropped from the rendered catalogue.
+    [Theory]
+    [InlineData(true, "trainings-fr.json")]
+    [InlineData(false, "trainings-en.json")]
+    public void TrainingCategories_Ordered_CoversEveryCategoryInData(bool fr, string file)
     {
-        HashSet<string> allowed = new(StringComparer.Ordinal) { ".NET", "Azure", "Vibe coding & IA", "Architecture & DevOps" };
-        Training[]? fr = JsonSerializer.Deserialize<Training[]>(
-            File.ReadAllText(LocateDataFile("trainings-fr.json")),
+        Training[]? items = JsonSerializer.Deserialize<Training[]>(
+            File.ReadAllText(LocateDataFile(file)),
             new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
-        Assert.NotNull(fr);
-        Assert.All(fr!, t => Assert.Contains(t.Category, allowed));
+        Assert.NotNull(items);
+        HashSet<string> ordered = new(TrainingCategories.Ordered(fr), StringComparer.Ordinal);
+        Assert.All(items!, t => Assert.Contains(t.Category, ordered));
     }
 
     private static Training Sample(string slug) => new()

--- a/IdeaStudio.Website.Tests/StaticFileEncodingTests.cs
+++ b/IdeaStudio.Website.Tests/StaticFileEncodingTests.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+
+namespace IdeaStudio.Website.Tests;
+
+/// <summary>
+/// Guards the encoding of hand-maintained static files under wwwroot. A leading UTF-8
+/// BOM makes strict parsers throw (ai.txt is JSON consumed by crawlers/agents) or
+/// mis-read the first line (robots.txt), so these files must have no BOM.
+/// </summary>
+public class StaticFileEncodingTests
+{
+    private static readonly byte[] Utf8Bom = [0xEF, 0xBB, 0xBF];
+
+    [Theory]
+    [InlineData("ai.txt")]
+    [InlineData("robots.txt")]
+    [InlineData("llms.txt")]
+    [InlineData("sitemap.xml")]
+    public void RootStaticFile_HasNoUtf8Bom(string fileName)
+    {
+        byte[] bytes = File.ReadAllBytes(LocateWwwrootFile(fileName));
+
+        bool startsWithBom = bytes.Length >= 3
+            && bytes[0] == Utf8Bom[0] && bytes[1] == Utf8Bom[1] && bytes[2] == Utf8Bom[2];
+        Assert.False(startsWithBom, $"{fileName} starts with a UTF-8 BOM; re-save it without one.");
+    }
+
+    [Fact]
+    public void AiTxt_ParsesAsJson()
+    {
+        using JsonDocument _ = JsonDocument.Parse(File.ReadAllText(LocateWwwrootFile("ai.txt")));
+    }
+
+    private static string LocateWwwrootFile(string fileName)
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "IdeaStudio.sln")))
+            dir = dir.Parent;
+        if (dir is null)
+            throw new InvalidOperationException("Could not locate repo root from " + AppContext.BaseDirectory);
+        return Path.Combine(dir.FullName, "IdeaStudio.Website", "wwwroot", fileName);
+    }
+}

--- a/IdeaStudio.Website/Components/CultureSelector.razor
+++ b/IdeaStudio.Website/Components/CultureSelector.razor
@@ -11,7 +11,7 @@
         <div class="ds-culture-selector-backdrop" aria-hidden="true" @onclick="CloseMenu"></div>
     }
     <button class="ds-btn ds-btn-sm" type="button" @ref="triggerButton"
-        @onclick="ToggleOpen" aria-haspopup="menu" aria-expanded="@isOpen" aria-label="@changeLanguageText">
+        @onclick="ToggleOpen" aria-haspopup="menu" aria-expanded="@(isOpen ? "true" : "false")" aria-label="@changeLanguageText">
         <i class="fas fa-globe" aria-hidden="true"></i>
         <span>@GetCurrentCultureDisplayName()</span>
     </button>

--- a/IdeaStudio.Website/Components/TrainingCatalogue.razor
+++ b/IdeaStudio.Website/Components/TrainingCatalogue.razor
@@ -2,15 +2,16 @@
 @inherits LocalizedComponent
 
 @{
-    string[] orderedCategories = new[] { ".NET", "Azure", "Vibe coding & IA", "Architecture & DevOps" };
-    var grouped = orderedCategories
+    bool fr = CultureService.CurrentCulture.Name.StartsWith("fr");
+    string[] orderedCategories = TrainingCategories.Ordered(fr);
+    (string Category, Training[] Items)[] grouped = orderedCategories
         .Select(cat => (Category: cat, Items: Trainings.Where(t => t.Category == cat).ToArray()))
         .Where(g => g.Items.Length > 0)
         .ToArray();
 }
 
 <div class="ds-training-catalogue">
-    @foreach (var group in grouped)
+    @foreach ((string Category, Training[] Items) group in grouped)
     {
         <section class="ds-training-catalogue-group" data-reveal>
             <h3 class="ds-training-catalogue-category">@group.Category</h3>

--- a/IdeaStudio.Website/MainLayout.razor
+++ b/IdeaStudio.Website/MainLayout.razor
@@ -81,6 +81,7 @@
         StateHasChanged();
         _ = Analytics.TrackPageViewAsync(e.Location);
         _ = UpdateHtmlLangAsync();
+        _ = SceneTheme.NotifyRouteChangedAsync();
     }
 
     private void OnConsentChanged()

--- a/IdeaStudio.Website/Models/TrainingCategories.cs
+++ b/IdeaStudio.Website/Models/TrainingCategories.cs
@@ -1,0 +1,13 @@
+namespace IdeaStudio.Website.Models;
+
+/// <summary>
+/// Single source of truth for the training-family display order. Only the
+/// "Vibe coding" track's label differs by culture (IA in FR, AI in EN); these
+/// strings MUST match the <c>category</c> values in <c>trainings-{fr,en}.json</c>
+/// so grouping never silently drops a whole family (the EN "AI" bug).
+/// </summary>
+public static class TrainingCategories
+{
+    public static string[] Ordered(bool fr) =>
+        [".NET", "Azure", fr ? "Vibe coding & IA" : "Vibe coding & AI", "Architecture & DevOps"];
+}

--- a/IdeaStudio.Website/Pages/Trainings.razor
+++ b/IdeaStudio.Website/Pages/Trainings.razor
@@ -71,11 +71,9 @@
 @code {
     private IReadOnlyList<Training> trainings = Array.Empty<Training>();
 
-    // Display order of the four training families. The "Vibe coding" track is the
-    // only category whose label differs by culture (IA in FR, AI in EN); these
-    // strings must match the `category` values in trainings-{fr,en}.json for grouping.
-    private string[] OrderedCategories =>
-        new[] { ".NET", "Azure", Fr ? "Vibe coding & IA" : "Vibe coding & AI", "Architecture & DevOps" };
+    // Training-family display order — single source of truth in TrainingCategories,
+    // shared with TrainingCatalogue so the two lists can never drift (the EN "AI" bug).
+    private string[] OrderedCategories => TrainingCategories.Ordered(Fr);
 
     private string seoTitle = "Formations .NET, Azure & IA | IdeaStud.io";
     private string seoDescription = "";

--- a/IdeaStudio.Website/Services/ISceneTheme.cs
+++ b/IdeaStudio.Website/Services/ISceneTheme.cs
@@ -18,4 +18,11 @@ public interface ISceneTheme
 
     /// <summary>Triggers a brief <c>html.is-pulsing</c> window so SCSS can react to a state change.</summary>
     Task PulseAsync();
+
+    /// <summary>
+    /// Notifies the runtime that a client-side navigation occurred, so it can rewire
+    /// reveals and re-measure the hero (nav-morph) for the new page. No-op if the
+    /// runtime has not booted yet.
+    /// </summary>
+    Task NotifyRouteChangedAsync();
 }

--- a/IdeaStudio.Website/Services/SceneTheme.cs
+++ b/IdeaStudio.Website/Services/SceneTheme.cs
@@ -37,6 +37,15 @@ public sealed class SceneTheme : ISceneTheme, IAsyncDisposable
         await mod.InvokeVoidAsync("pulse");
     }
 
+    public async Task NotifyRouteChangedAsync()
+    {
+        // Only fire if the runtime is already booted; never force-load the bundle
+        // just to announce a navigation.
+        if (module is null) return;
+        try { await module.InvokeVoidAsync("notifyRouteChanged"); }
+        catch (JSDisconnectedException) { /* runtime gone */ }
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (module is not null)

--- a/IdeaStudio.Website/wwwroot/ai.txt
+++ b/IdeaStudio.Website/wwwroot/ai.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "IdeaStud.io",
   "type": "portfolio",
   "owner": "Andrés Talavera",

--- a/IdeaStudio.Website/wwwroot/robots.txt
+++ b/IdeaStudio.Website/wwwroot/robots.txt
@@ -1,4 +1,4 @@
-﻿# robots.txt for IdeaStud.io
+# robots.txt for IdeaStud.io
 # https://ideastud.io
 
 User-agent: *

--- a/IdeaStudio.Website/wwwroot/src/cinema/index.js
+++ b/IdeaStudio.Website/wwwroot/src/cinema/index.js
@@ -9,7 +9,7 @@ import { HeroState } from './engine/state.js';
 import { createMeshPass } from './passes/mesh.js';
 import { attachReveals, disposeReveals } from './interactions/reveals.js';
 import { attachCursor, disposeCursor } from './interactions/cursor.js';
-import { attachNavMorph, disposeNavMorph } from './interactions/nav-morph.js';
+import { attachNavMorph, disposeNavMorph, refreshNavMorph } from './interactions/nav-morph.js';
 import { prefersReducedMotion, batteryLow, setMotionMode } from './utils/perf.js';
 export { mountSignature } from './signature/signature-name.js';
 import './analytics/index.js'; // side-effect: defines window.ideaAnalytics
@@ -49,6 +49,14 @@ export async function initialize() {
   attachCursor();
   attachNavMorph();
 
+  // Route-change hook: after Blazor swaps the DOM, rewire reveals and re-measure
+  // the hero so nav-morph state can't stay stale from the previous page. Registered
+  // here (before any early return) so it survives reduced-motion / no-WebGL paths.
+  window.addEventListener('ideastudio:routechanged', () => {
+    attachReveals();
+    refreshNavMorph();
+  });
+
   const canvas = document.getElementById('gl-canvas');
   if (!canvas) return;
 
@@ -85,11 +93,12 @@ export async function initialize() {
 
   // Reading-progress rail is driven entirely by CSS (animation-timeline:
   // scroll(root)) in components/_progress.scss — no JS scroll listener here.
+}
 
-  // Route-change hook: rewire reveals when the DOM swaps via Blazor's router.
-  window.addEventListener('ideastudio:routechanged', () => {
-    attachReveals();
-  });
+// Called by the app (via ISceneTheme) after a Blazor client-side navigation.
+// Fires the DOM event the runtime listens for in initialize().
+export function notifyRouteChanged() {
+  window.dispatchEvent(new CustomEvent('ideastudio:routechanged'));
 }
 
 export function applyTheme(scene) {

--- a/IdeaStudio.Website/wwwroot/src/cinema/interactions/nav-morph.js
+++ b/IdeaStudio.Website/wwwroot/src/cinema/interactions/nav-morph.js
@@ -55,6 +55,14 @@ export function attachNavMorph() {
   attachNavMorph._schedule = schedule;
 }
 
+// Recompute after a Blazor client-side navigation: the DOM has swapped, so the
+// previous page's data-hero-state / --hero-progress may be stale (the user may
+// not have scrolled). Double rAF lets Blazor paint the new page before we measure
+// the new (or now-absent) hero.
+export function refreshNavMorph() {
+  requestAnimationFrame(() => requestAnimationFrame(writeState));
+}
+
 export function disposeNavMorph() {
   if (attachNavMorph._schedule) {
     window.removeEventListener('scroll', attachNavMorph._schedule);


### PR DESCRIPTION
First increment from the full-site audit (`/council` "what can I improve?"). Correctness & a11y batch — all four are verified fixes with tests.

## A1 · EN trainer page silently dropped the AI-training family (content loss)
`Components/TrainingCatalogue.razor` hard-coded the **FR** category label `"Vibe coding & IA"`. `trainings-en.json` uses `"Vibe coding & AI"`, so on `/en/services/trainer` that group matched **0** items and 4 modules (`ai-on-premise`, `claude-code-team`, `copilot-advanced`, `mcp-server-design`) never rendered.
- Centralized the culture-aware family order in `Models/TrainingCategories` — **one source of truth** now shared by `TrainingCatalogue` and `Pages/Trainings.razor` (the two lists had drifted, which is what caused the bug).
- Strengthened the test: `TrainingCategories_Ordered_CoversEveryCategoryInData` now runs for **both** cultures (the old test only checked FR).

## A2 · CultureSelector `aria-expanded` vanished when closed (WCAG 4.1.2)
`aria-expanded="@isOpen"` (bool) drops the attribute entirely when false. Switched to the string form already used in `Masthead.razor`.

## A3 · `ideastudio:routechanged` had no dispatcher (stale nav state)
Nothing dispatched the event, so `nav-morph` kept the previous page's `data-hero-state` / `--hero-progress` after a client-side navigation without scrolling.
- Added `ISceneTheme.NotifyRouteChangedAsync` → `notifyRouteChanged()` bundle export, dispatched from `MainLayout.OnLocationChanged`.
- Moved the listener registration **before** the reduced-motion / no-WebGL early returns (it previously never registered in those modes) and made it refresh nav-morph.

## A4 · UTF-8 BOM in `ai.txt` and `robots.txt`
A BOM makes strict `JSON.parse` throw (`ai.txt` is JSON for crawlers/agents) and can mis-read the first `robots` line. Stripped both; added `StaticFileEncodingTests` to guard root static files.

## Verification
- `dotnet build IdeaStudio.sln` — clean (0 warnings)
- `dotnet test IdeaStudio.sln` — **176 passing** (+7 new)
- Bundle rebuilt, 8.3 KB gzip (under budget)

Remaining audit workstreams (security/CI, SEO/content coherence, perf/hygiene) will follow as separate increments; one item (training day-rate reconcile) needs an owner decision first.