### PR TITLE
chore(security): dependency-audit gate, function tests, contact caps, CSP trim (audit Wave 2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+# Keeps dependencies patched across every ecosystem in the repo. Grouped, weekly,
+# low-noise PRs; security updates are opened regardless of the schedule.
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dotnet:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: "/IdeaStudio.Website"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      asset-pipeline:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: "/netlify/functions"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      functions:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <!-- Solution-wide defaults. -->
+  <PropertyGroup>
+    <!-- Supply-chain gate: audit NuGet dependencies (direct + transitive) on every
+         restore. Emits NU1901-1904 warnings (non-blocking) when a referenced package
+         has a known advisory, so vulnerable drift surfaces in local + CI build logs. -->
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+  </PropertyGroup>
+</Project>

--- a/netlify.toml
+++ b/netlify.toml
@@ -61,16 +61,20 @@
     #   #3 gtag consent sha256-nhiW/ulTwWDu5HfFOa9Ly2HsbaDzsCsPHDLM9sIwWkM=
     #   #4 gtag loader  sha256-bhXkdC3LSM4yWGRebqKoCfRP6qwe5TB+6x1zxsOq3eQ=
     # style-src keeps 'unsafe-inline' (Blazor injects inline styles at runtime).
-    # Allowed third parties: Google Analytics/Tag Manager, Microsoft Clarity, Meta Pixel, Calendly.
-    Content-Security-Policy   = "default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'sha256-WiS5ra6UvDHlQV9ETVu3ahTTGZKP2CzHRxEUwB/YCi8=' 'sha256-myYqLbOoe9z9BMmIk5lkleXHh1wYTOJIhe5d82Gh7Hc=' 'sha256-nhiW/ulTwWDu5HfFOa9Ly2HsbaDzsCsPHDLM9sIwWkM=' 'sha256-bhXkdC3LSM4yWGRebqKoCfRP6qwe5TB+6x1zxsOq3eQ=' 'wasm-unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://www.clarity.ms https://connect.facebook.net https://assets.calendly.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://*.clarity.ms https://www.facebook.com; frame-src https://calendly.com https://assets.calendly.com; form-action 'self'; frame-ancestors 'none'"
+    # Allowed third parties: Google Analytics/Tag Manager, Microsoft Clarity, Calendly.
+    # Meta Pixel is disabled (analytics/index.js META_PIXEL_ID = null), so its origins
+    # (connect.facebook.net in script-src, www.facebook.com in connect-src) are removed
+    # here — re-add them in the same change that sets META_PIXEL_ID.
+    Content-Security-Policy   = "default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'sha256-WiS5ra6UvDHlQV9ETVu3ahTTGZKP2CzHRxEUwB/YCi8=' 'sha256-myYqLbOoe9z9BMmIk5lkleXHh1wYTOJIhe5d82Gh7Hc=' 'sha256-nhiW/ulTwWDu5HfFOa9Ly2HsbaDzsCsPHDLM9sIwWkM=' 'sha256-bhXkdC3LSM4yWGRebqKoCfRP6qwe5TB+6x1zxsOq3eQ=' 'wasm-unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://www.clarity.ms https://assets.calendly.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://*.clarity.ms; frame-src https://calendly.com https://assets.calendly.com; form-action 'self'; frame-ancestors 'none'"
 
 # Netlify Functions (TypeScript .mts, ES modules).
 # resume-pdf renders a PDF on demand from wwwroot/data/resume-{culture}.json
-# using puppeteer-core + @sparticuz/chromium. The Chromium binary is too
-# heavy to bundle, so it must stay external.
+# using puppeteer-core + @sparticuz/chromium-min. chromium-min ships WITHOUT the
+# Chromium binary (fetched + integrity-checked at cold start, see _lib/chromium.mts),
+# so it bundles fine — no external_node_modules entry is needed. (The former
+# "@sparticuz/chromium" entry matched no installed package and was dead.)
 [functions]
-  node_bundler        = "esbuild"
-  external_node_modules = ["@sparticuz/chromium"]
+  node_bundler = "esbuild"
 
 # Rate limiting for the public, unauthenticated SMTP relay (contact form) is
 # enforced at the edge via the function's own `config.rateLimit` export in

--- a/netlify/functions/_lib/chromium.mts
+++ b/netlify/functions/_lib/chromium.mts
@@ -1,4 +1,4 @@
-import { createHash, timingSafeEqual } from "node:crypto";
+import { createHash } from "node:crypto";
 import { createReadStream, createWriteStream, existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -7,6 +7,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { extract } from "tar-fs";
 import chromium from "@sparticuz/chromium-min";
+import { digestsMatch, isHttpsUrl } from "./integrity.mjs";
 
 // SHA-256 of the upstream Sparticuz Chromium pack that matches the
 // @sparticuz/chromium-min version pinned in package.json
@@ -25,25 +26,8 @@ const cachedBinaryPath = join(tmpdir(), "chromium");
 const packTarPath = join(tmpdir(), "chromium-pack.tar");
 const packDir = join(tmpdir(), "chromium-pack");
 
-function isHttpsUrl(value: string): boolean {
-  try {
-    return new URL(value).protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
 function expectedDigest(): string {
   return (process.env.CHROMIUM_PACK_SHA256 ?? EXPECTED_PACK_SHA256).toLowerCase();
-}
-
-function digestsMatch(actual: string, expected: string): boolean {
-  const actualBytes = Buffer.from(actual, "hex");
-  const expectedBytes = Buffer.from(expected, "hex");
-  if (actualBytes.length === 0 || actualBytes.length !== expectedBytes.length) {
-    return false;
-  }
-  return timingSafeEqual(actualBytes, expectedBytes);
 }
 
 async function sha256File(path: string): Promise<string> {

--- a/netlify/functions/_lib/contact-validation.mts
+++ b/netlify/functions/_lib/contact-validation.mts
@@ -1,0 +1,67 @@
+// Pure validation + sanitization for the contact form. Kept free of any heavy
+// imports (no nodemailer) so it can be unit-tested in isolation.
+
+export interface ContactPayload {
+  name?: string;
+  email?: string;
+  subject?: string;
+  message?: string;
+  website?: string; // honeypot
+}
+
+export interface ContactFields {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}
+
+export type ContactValidation =
+  | { ok: true; fields: ContactFields }
+  | { ok: false; status: number; error: string };
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+// Upper bounds on each field so a caller cannot relay a multi-megabyte body over
+// SMTP (relay-amplification / abuse), even within Netlify's request-size limit.
+export const FIELD_LIMITS = {
+  name: 200,
+  email: 254, // RFC 5321 max address length
+  subject: 300,
+  message: 5000,
+} as const;
+
+const MESSAGE_MIN = 10;
+
+// Strip CR/LF so attacker-supplied values cannot inject extra SMTP/MIME headers
+// when interpolated into address fields. Internal newlines collapse to a single
+// space; surrounding whitespace is trimmed. Spaces are preserved so display
+// names like "Ada Lovelace" stay intact.
+export const stripCrlf = (value: string): string => value.replace(/[\r\n]+/g, " ").trim();
+
+// Returns true when the honeypot field was filled — a bot. The caller should
+// pretend success and send nothing.
+export const isHoneypotTripped = (payload: ContactPayload): boolean =>
+  (payload.website ?? "").trim().length > 0;
+
+export function validateContact(payload: ContactPayload): ContactValidation {
+  const name = (payload.name ?? "").trim();
+  const email = (payload.email ?? "").trim();
+  const subject = (payload.subject ?? "").trim();
+  const message = (payload.message ?? "").trim();
+
+  if (!name || !EMAIL_RE.test(email) || message.length < MESSAGE_MIN) {
+    return { ok: false, status: 422, error: "Validation failed" };
+  }
+
+  if (
+    name.length > FIELD_LIMITS.name ||
+    email.length > FIELD_LIMITS.email ||
+    subject.length > FIELD_LIMITS.subject ||
+    message.length > FIELD_LIMITS.message
+  ) {
+    return { ok: false, status: 422, error: "Field too long" };
+  }
+
+  return { ok: true, fields: { name, email, subject, message } };
+}

--- a/netlify/functions/_lib/contact-validation.test.mts
+++ b/netlify/functions/_lib/contact-validation.test.mts
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FIELD_LIMITS,
+  isHoneypotTripped,
+  stripCrlf,
+  validateContact,
+} from "./contact-validation.mjs";
+
+test("stripCrlf collapses CR/LF to a space and trims", () => {
+  assert.equal(stripCrlf("Ada\r\nLovelace"), "Ada Lovelace");
+  assert.equal(stripCrlf("  spaced  "), "spaced");
+  assert.equal(stripCrlf("a\nb\r\nc"), "a b c");
+  // Header-injection attempt: the injected header must not survive as a newline.
+  assert.equal(stripCrlf("me@x.com\r\nBcc: victim@y.com"), "me@x.com Bcc: victim@y.com");
+});
+
+test("isHoneypotTripped detects a filled hidden field", () => {
+  assert.equal(isHoneypotTripped({ website: "http://spam" }), true);
+  assert.equal(isHoneypotTripped({ website: "   " }), false);
+  assert.equal(isHoneypotTripped({}), false);
+});
+
+test("validateContact accepts a well-formed payload", () => {
+  const result = validateContact({
+    name: "Ada",
+    email: "ada@example.com",
+    subject: "Hello",
+    message: "This is long enough.",
+  });
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.fields.name, "Ada");
+});
+
+test("validateContact rejects bad email or too-short message", () => {
+  assert.equal(validateContact({ name: "A", email: "nope", message: "long enough here" }).ok, false);
+  assert.equal(validateContact({ name: "A", email: "a@b.co", message: "short" }).ok, false);
+  assert.equal(validateContact({ name: "", email: "a@b.co", message: "long enough here" }).ok, false);
+});
+
+test("validateContact caps oversized fields (relay-amplification guard)", () => {
+  const huge = "x".repeat(FIELD_LIMITS.message + 1);
+  const result = validateContact({ name: "A", email: "a@b.co", message: huge });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.status, 422);
+    assert.equal(result.error, "Field too long");
+  }
+
+  const longName = validateContact({
+    name: "n".repeat(FIELD_LIMITS.name + 1),
+    email: "a@b.co",
+    message: "long enough here",
+  });
+  assert.equal(longName.ok, false);
+});

--- a/netlify/functions/_lib/host.mts
+++ b/netlify/functions/_lib/host.mts
@@ -1,0 +1,48 @@
+// Pure SSRF guard for resume-pdf: resolves the origin the function is allowed to
+// fetch resume data from, never trusting an attacker-controllable Host header.
+// Kept import-free so it can be unit-tested without launching Chromium.
+
+// Hosts the function may render from. Netlify injects the real deploy origin via
+// URL / DEPLOY_PRIME_URL / DEPLOY_URL at runtime; those are added and preferred
+// over the request host when building the fetch base.
+export const STATIC_ALLOWED_HOSTS = [
+  "ideastud.io",
+  "www.ideastud.io",
+  "localhost",
+  "localhost:8888",
+  "127.0.0.1",
+  "127.0.0.1:8888",
+] as const;
+
+export interface HostEnv {
+  URL?: string;
+  DEPLOY_PRIME_URL?: string;
+  DEPLOY_URL?: string;
+}
+
+// Returns a trusted origin string, or null if the request host is not allowlisted.
+export function trustedBaseUrl(requestUrl: URL, env: HostEnv = process.env): string | null {
+  const allowed = new Set<string>(STATIC_ALLOWED_HOSTS);
+  for (const envOrigin of [env.URL, env.DEPLOY_PRIME_URL, env.DEPLOY_URL]) {
+    if (!envOrigin) continue;
+    try {
+      allowed.add(new URL(envOrigin).host);
+    } catch {
+      // Ignore malformed env origins.
+    }
+  }
+
+  if (!allowed.has(requestUrl.host)) {
+    return null;
+  }
+
+  const canonical = env.URL ?? env.DEPLOY_PRIME_URL;
+  if (canonical) {
+    try {
+      return new URL(canonical).origin;
+    } catch {
+      // Fall through to the allowlisted request origin.
+    }
+  }
+  return requestUrl.origin;
+}

--- a/netlify/functions/_lib/host.test.mts
+++ b/netlify/functions/_lib/host.test.mts
@@ -1,0 +1,31 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { trustedBaseUrl } from "./host.mjs";
+
+test("trustedBaseUrl allows a static allowlisted host", () => {
+  const base = trustedBaseUrl(new URL("https://ideastud.io/.netlify/functions/resume-pdf"), {});
+  assert.equal(base, "https://ideastud.io");
+});
+
+test("trustedBaseUrl rejects an unknown / spoofed host (SSRF guard)", () => {
+  assert.equal(trustedBaseUrl(new URL("https://evil.example/resume-pdf"), {}), null);
+  assert.equal(trustedBaseUrl(new URL("https://ideastud.io.attacker.com/x"), {}), null);
+});
+
+test("trustedBaseUrl trusts and prefers the Netlify-injected deploy origin", () => {
+  const env = { URL: "https://deploy--ideastudio.netlify.app" };
+  const base = trustedBaseUrl(new URL("https://deploy--ideastudio.netlify.app/x"), env);
+  assert.equal(base, "https://deploy--ideastudio.netlify.app");
+});
+
+test("trustedBaseUrl returns the canonical URL origin even when the request host differs but is allowlisted", () => {
+  const env = { URL: "https://ideastud.io" };
+  // A request to the www host, with canonical env pointing at the apex.
+  const base = trustedBaseUrl(new URL("https://www.ideastud.io/x"), env);
+  assert.equal(base, "https://ideastud.io");
+});
+
+test("trustedBaseUrl ignores a malformed env origin", () => {
+  const base = trustedBaseUrl(new URL("https://ideastud.io/x"), { URL: "not a url" });
+  assert.equal(base, "https://ideastud.io");
+});

--- a/netlify/functions/_lib/integrity.mts
+++ b/netlify/functions/_lib/integrity.mts
@@ -1,0 +1,22 @@
+// Pure integrity helpers for the Chromium-pack supply-chain check. Only depends
+// on node:crypto so it can be unit-tested without tar-fs / chromium-min.
+import { timingSafeEqual } from "node:crypto";
+
+export function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// Constant-time compare of two hex digests. False on length mismatch or empty
+// input, so a malformed/absent digest can never match.
+export function digestsMatch(actual: string, expected: string): boolean {
+  const actualBytes = Buffer.from(actual, "hex");
+  const expectedBytes = Buffer.from(expected, "hex");
+  if (actualBytes.length === 0 || actualBytes.length !== expectedBytes.length) {
+    return false;
+  }
+  return timingSafeEqual(actualBytes, expectedBytes);
+}

--- a/netlify/functions/_lib/integrity.test.mts
+++ b/netlify/functions/_lib/integrity.test.mts
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { digestsMatch, isHttpsUrl } from "./integrity.mjs";
+
+test("isHttpsUrl only accepts https", () => {
+  assert.equal(isHttpsUrl("https://example.com/x.tar"), true);
+  assert.equal(isHttpsUrl("http://example.com/x.tar"), false);
+  assert.equal(isHttpsUrl("/local/bin"), false);
+  assert.equal(isHttpsUrl("not a url"), false);
+});
+
+test("digestsMatch is true only for an exact digest", () => {
+  const digest = createHash("sha256").update("payload").digest("hex");
+  assert.equal(digestsMatch(digest, digest), true);
+  assert.equal(digestsMatch(digest, digest.replace(/.$/, "0")), false);
+});
+
+test("digestsMatch is false on length mismatch or empty input", () => {
+  assert.equal(digestsMatch("", "abcd"), false);
+  assert.equal(digestsMatch("ab", "abcd"), false);
+  assert.equal(digestsMatch("", ""), false);
+});

--- a/netlify/functions/_lib/render.mts
+++ b/netlify/functions/_lib/render.mts
@@ -9,7 +9,7 @@ const ESCAPE_MAP: Record<string, string> = {
   "'": "&#39;",
 };
 
-function escape(s: string): string {
+export function escape(s: string): string {
   return s.replace(/[&<>"']/g, (ch) => ESCAPE_MAP[ch] ?? ch);
 }
 

--- a/netlify/functions/_lib/render.test.mts
+++ b/netlify/functions/_lib/render.test.mts
@@ -1,0 +1,14 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { escape } from "./render.mjs";
+
+test("escape neutralizes every HTML-significant character", () => {
+  assert.equal(
+    escape(`<script>alert("x") & 'y'</script>`),
+    "&lt;script&gt;alert(&quot;x&quot;) &amp; &#39;y&#39;&lt;/script&gt;",
+  );
+});
+
+test("escape leaves plain text untouched", () => {
+  assert.equal(escape("Andrés Talavera — .NET"), "Andrés Talavera — .NET");
+});

--- a/netlify/functions/contact.mts
+++ b/netlify/functions/contact.mts
@@ -1,5 +1,11 @@
 import type { Config, Context } from "@netlify/functions";
 import nodemailer from "nodemailer";
+import {
+  type ContactPayload,
+  isHoneypotTripped,
+  stripCrlf,
+  validateContact,
+} from "./_lib/contact-validation.mjs";
 
 // Contact-form handler. Receives the JSON posted by Pages/Contact.razor and
 // relays it to an inbox over SMTP. Configure via environment variables in the
@@ -14,22 +20,6 @@ import nodemailer from "nodemailer";
 //
 // Until these are set the function returns 503 and the form shows its error
 // state (with a mailto fallback), so nothing breaks before configuration.
-
-interface ContactPayload {
-  name?: string;
-  email?: string;
-  subject?: string;
-  message?: string;
-  website?: string; // honeypot
-}
-
-const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
-
-// Strip CR/LF so attacker-supplied values cannot inject extra SMTP/MIME
-// headers when interpolated into address fields. Internal newlines collapse
-// to a single space; surrounding whitespace is trimmed. Spaces are preserved
-// so display names like "Ada Lovelace" stay intact.
-const stripCrlf = (value: string): string => value.replace(/[\r\n]+/g, " ").trim();
 
 const json = (status: number, body: Record<string, unknown>): Response =>
   new Response(JSON.stringify(body), {
@@ -50,18 +40,15 @@ export default async (req: Request, _context: Context): Promise<Response> => {
   }
 
   // Honeypot — a bot filled the hidden field. Pretend success, send nothing.
-  if (payload.website && payload.website.trim().length > 0) {
+  if (isHoneypotTripped(payload)) {
     return json(200, { success: true });
   }
 
-  const name = (payload.name ?? "").trim();
-  const email = (payload.email ?? "").trim();
-  const subject = (payload.subject ?? "").trim();
-  const message = (payload.message ?? "").trim();
-
-  if (!name || !EMAIL_RE.test(email) || message.length < 10) {
-    return json(422, { success: false, error: "Validation failed" });
+  const validation = validateContact(payload);
+  if (!validation.ok) {
+    return json(validation.status, { success: false, error: validation.error });
   }
+  const { name, email, subject, message } = validation.fields;
 
   const host = process.env.SMTP_HOST;
   const user = process.env.SMTP_USER;

--- a/netlify/functions/package-lock.json
+++ b/netlify/functions/package-lock.json
@@ -15,7 +15,453 @@
         "tar-fs": "^3.1.2"
       },
       "devDependencies": {
-        "@types/tar-fs": "^2.0.4"
+        "@types/node": "^22.10.2",
+        "@types/nodemailer": "^7.0.2",
+        "@types/tar-fs": "^2.0.4",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@netlify/functions": {
@@ -79,13 +525,23 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.12.tgz",
+      "integrity": "sha512-80vKwiIsVSyFA1rRovH59jNPLBOuc6dRZIHEu40gXTkBkZnQv8vog1xSGEb9j5q/tdMAs5ivvDR2pLTU0hGHXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/tar-fs": {
@@ -393,6 +849,48 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -496,6 +994,21 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -884,16 +1397,49 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/typed-query-selector": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
       "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "license": "MIT"
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/netlify/functions/package.json
+++ b/netlify/functions/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "description": "Netlify Functions for IdeaStudio (PDF resume generation, ...).",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test \"_lib/*.test.mts\""
+  },
   "dependencies": {
     "@netlify/functions": "^5.2.0",
     "@sparticuz/chromium-min": "^148.0.0",
@@ -12,6 +16,10 @@
     "tar-fs": "^3.1.2"
   },
   "devDependencies": {
-    "@types/tar-fs": "^2.0.4"
+    "@types/nodemailer": "^7.0.2",
+    "@types/node": "^22.10.2",
+    "@types/tar-fs": "^2.0.4",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
   }
 }

--- a/netlify/functions/resume-pdf.mts
+++ b/netlify/functions/resume-pdf.mts
@@ -3,6 +3,7 @@ import puppeteer from "puppeteer-core";
 import chromium from "@sparticuz/chromium-min";
 import { resolveChromiumExecutable } from "./_lib/chromium.mjs";
 import { renderResumeHtml } from "./_lib/render.mjs";
+import { trustedBaseUrl } from "./_lib/host.mjs";
 import type { Culture, Resume } from "./_lib/types.mjs";
 
 // chromium-min ships without the Chromium binary so the deployed function
@@ -14,51 +15,13 @@ const CHROMIUM_PACK_URL =
   process.env.CHROMIUM_PACK_URL ??
   "https://github.com/Sparticuz/chromium/releases/download/v148.0.0/chromium-v148.0.0-pack.x64.tar";
 
-// Hosts the function is allowed to render from. The fetch target is never
-// derived from an attacker-controllable Host header: a spoofed Host would
-// otherwise make the function fetch and render attacker-controlled "resume"
-// data (SSRF). Netlify injects the real deploy origin via URL / DEPLOY_PRIME_URL
-// at runtime; those are added to the set below and preferred over the request
-// host when building the fetch base.
-const STATIC_ALLOWED_HOSTS = [
-  "ideastud.io",
-  "www.ideastud.io",
-  "localhost",
-  "localhost:8888",
-  "127.0.0.1",
-  "127.0.0.1:8888",
-] as const;
+// The SSRF host allowlist + fetch-origin resolution lives in _lib/host.mts
+// (trustedBaseUrl), kept pure so it can be unit-tested.
 
 const SECURITY_HEADERS = {
   "X-Content-Type-Options": "nosniff",
   "Referrer-Policy": "no-referrer",
 } as const;
-
-function trustedBaseUrl(requestUrl: URL): string | null {
-  const allowed = new Set<string>(STATIC_ALLOWED_HOSTS);
-  for (const envOrigin of [process.env.URL, process.env.DEPLOY_PRIME_URL, process.env.DEPLOY_URL]) {
-    if (!envOrigin) continue;
-    try {
-      allowed.add(new URL(envOrigin).host);
-    } catch {
-      // Ignore malformed env origins.
-    }
-  }
-
-  if (!allowed.has(requestUrl.host)) {
-    return null;
-  }
-
-  const canonical = process.env.URL ?? process.env.DEPLOY_PRIME_URL;
-  if (canonical) {
-    try {
-      return new URL(canonical).origin;
-    } catch {
-      // Fall through to the allowlisted request origin.
-    }
-  }
-  return requestUrl.origin;
-}
 
 function textResponse(status: number, body: string): Response {
   return new Response(body, {

--- a/netlify/functions/tsconfig.json
+++ b/netlify/functions/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.mts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Second increment from the full-site audit. Security & CI hardening. Disjoint from Wave 1 (PR #76).

## B1 · Dependency-audit gate (supply-chain blind spot)
- `Directory.Build.props` enables `NuGetAudit` (direct **+ transitive**) on restore.
- `.github/dependabot.yml` for nuget, both npm dirs, and github-actions.

## B2 · Netlify functions had zero coverage and no typecheck (highest-risk code)
- Extracted the pure, security-critical helpers into `_lib/` (`contact-validation`, `host`, `integrity`) and exported `render.escape` — testable without importing nodemailer/puppeteer.
- Added `tsconfig.json` + a `typecheck` script (`tsc --noEmit`) and **15 `node:test` unit tests** (via `tsx`) covering `stripCrlf`, field caps, `trustedBaseUrl` (SSRF allowlist + spoof rejection), `digestsMatch`, `isHttpsUrl`, `escape`.

## B3 · `contact.mts` had no field-length caps (relay-amplification vector)
`validateContact` caps name ≤200, email ≤254, subject ≤300, message ≤5000 → 422 on overflow. Behaviour otherwise unchanged.

## B4 · Trim dead CSP origins + stale function config
Meta Pixel is disabled (`META_PIXEL_ID = null`) → removed its origins (`connect.facebook.net`, `www.facebook.com`) from the CSP. Removed the `external_node_modules` entry naming a non-existent package.

## ⚠️ Follow-up needed — CI wiring held back
The `ci.yml` change (npm-audit step + a `functions` job running `npm run typecheck` and `npm test`) **could not be pushed** — the token lacks GitHub's `workflow` scope. The tests/typecheck exist and pass locally; the CI wiring must be applied with a `workflow`-scoped token. Diff provided by the author.

## Verification
- `.NET`: `dotnet build` clean (0 warnings — NuGet audit found no advisories), **170 tests** green.
- `functions`: `npm run typecheck` exit 0, `npm test` **15 passing** (verified locally).