### PR TITLE
content(seo): unify day-rate band, Twitter meta, sitemap dates, OG dims (audit Wave 3)

### DIFF
--- a/IdeaStudio.Website/Components/SeoHead.razor
+++ b/IdeaStudio.Website/Components/SeoHead.razor
@@ -41,6 +41,15 @@
     {
         <meta property="og:image" content="@OgImage" />
         <meta property="og:image:alt" content="@(OgImageAlt ?? Title)" />
+        @if (!string.IsNullOrEmpty(OgImageType))
+        {
+            <meta property="og:image:type" content="@OgImageType" />
+        }
+        @if (OgImageWidth is int w && OgImageHeight is int h)
+        {
+            <meta property="og:image:width" content="@w" />
+            <meta property="og:image:height" content="@h" />
+        }
     }
     @if (!string.IsNullOrEmpty(SiteName))
     {
@@ -123,6 +132,15 @@
 
     /// <summary>Alt text for OG image</summary>
     [Parameter] public string? OgImageAlt { get; set; }
+
+    /// <summary>OG image MIME type, e.g. "image/jpeg" (optional)</summary>
+    [Parameter] public string? OgImageType { get; set; }
+
+    /// <summary>OG image width in pixels (optional; emitted with height)</summary>
+    [Parameter] public int? OgImageWidth { get; set; }
+
+    /// <summary>OG image height in pixels (optional; emitted with width)</summary>
+    [Parameter] public int? OgImageHeight { get; set; }
 
     /// <summary>Site name for Open Graph</summary>
     [Parameter] public string? SiteName { get; set; }

--- a/IdeaStudio.Website/Pages/Faq.razor
+++ b/IdeaStudio.Website/Pages/Faq.razor
@@ -84,7 +84,7 @@
         new("Travailler ensemble", new (string, string)[]
         {
             ("Quels projets acceptez-vous ?", "Conseil, techlead, formation, accompagnement IA, ou réalisations sur-mesure, .NET, Azure, mobile, web. Si le cadrage est clair et le délai sain, j'y vais."),
-            ("Quels sont vos tarifs ?", "Tarif journalier à partir de 600 € (conseil, techlead) et 800 € (formation, IA en entreprise), ajusté selon la durée, la complexité et le niveau d'implication. Premier échange de 30 minutes offert, devis chiffré sous 24 h."),
+            ("Quels sont vos tarifs ?", "Tarif journalier de 600 à 800 € selon la nature de la mission (conseil, techlead, formation, IA en entreprise), la durée, la complexité et le niveau d'implication. Premier échange de 30 minutes offert, devis chiffré sous 24 h."),
             ("Où pouvez-vous intervenir ?", "Lyon, Paris, Genève, Fribourg, sur site, hybride ou full-remote selon votre besoin. Je me déplace pour les kick-offs, les ateliers techniques et les sessions de formation."),
             ("Comment travaille-t-on ensemble ?", "En portage salarial via OpenWork (société française) : un cadre contractuel simple et sécurisé pour vous comme pour moi. Facturation en EUR par défaut, CHF possible pour les missions côté suisse."),
             ("Sous quel délai pouvez-vous démarrer ?", "Un appel de cadrage sous quelques jours, un devis sous 24 h après un brief court. Les missions courtes démarrent généralement sous une à deux semaines selon mon planning."),
@@ -111,7 +111,7 @@
         new("Working together", new (string, string)[]
         {
             ("What projects do you take on?", "Consulting, tech-lead, training, AI enablement, or custom delivery, .NET, Azure, mobile, web. If the scope is clear and the timeline sane, I'm in."),
-            ("What are your rates?", "Day rate from 600 € (consulting, tech-lead) and 800 € (training, enterprise AI). Adjusted for duration, complexity and level of involvement. First 30-minute call is free, a quote within 24h."),
+            ("What are your rates?", "Day rate 600–800 € depending on the nature of the engagement (consulting, tech-lead, training, enterprise AI), duration, complexity and level of involvement. First 30-minute call is free, a quote within 24h."),
             ("Where do you work?", "Lyon, Paris, Geneva, Fribourg, on-site, hybrid or fully remote depending on your need. I travel for kick-offs, technical workshops and training sessions."),
             ("How do we work together?", "Via French wage-portage company OpenWork: a simple, secure contractual frame for both sides. Default invoicing in EUR, CHF available for Swiss assignments."),
             ("How fast can you start?", "A scoping call within days, a quote within 24h of a short brief. Short engagements typically start within one to two weeks depending on my schedule."),

--- a/IdeaStudio.Website/Pages/Home.razor
+++ b/IdeaStudio.Website/Pages/Home.razor
@@ -18,6 +18,11 @@
          Locale="@seoLocale"
          OgImage="https://ideastud.io/images/andres-talavera.jpeg"
          OgImageAlt="Andrés Talavera - .NET & Azure"
+         OgImageType="image/jpeg"
+         OgImageWidth="800"
+         OgImageHeight="800"
+         TwitterSite="@@imcresus_"
+         TwitterCreator="@@imcresus_"
          StructuredData="@seoStructuredData"
          SpeakableSelectors="@speakable" />
 

--- a/IdeaStudio.Website/wwwroot/ai.txt
+++ b/IdeaStudio.Website/wwwroot/ai.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "IdeaStud.io",
   "type": "portfolio",
   "owner": "Andrés Talavera",
@@ -10,8 +10,8 @@
   "experienceYears": 15,
   "pricing": {
     "currency": "EUR",
-    "dayRateConsulting": 600,
-    "dayRateTraining": 800,
+    "dayRateMin": 600,
+    "dayRateMax": 800,
     "freeScopingCall": true,
     "quoteWithinHours": 24,
     "commission": 0,

--- a/IdeaStudio.Website/wwwroot/llms.txt
+++ b/IdeaStudio.Website/wwwroot/llms.txt
@@ -13,8 +13,7 @@
 ## Key facts
 
 - **Rates**
-  - consulting / tech-lead: from `600 €` / day
-  - training / enterprise AI: from `800 €` / day
+  - day rate: `600–800 €` / day (consulting, tech-lead, training, enterprise AI — by scope, complexity & involvement)
   - first scoping call: free, 30 min
   - quote: within 24 h
 - **Engagement**

--- a/IdeaStudio.Website/wwwroot/sitemap.xml
+++ b/IdeaStudio.Website/wwwroot/sitemap.xml
@@ -4,7 +4,7 @@
   <!-- Home -->
   <url>
     <loc>https://ideastud.io/fr</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr" />
@@ -13,7 +13,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr" />
@@ -24,7 +24,7 @@
   <!-- Services hub -->
   <url>
     <loc>https://ideastud.io/fr/services</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services" />
@@ -33,7 +33,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/services</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services" />
@@ -44,7 +44,7 @@
   <!-- Services: Consultant .NET & Azure -->
   <url>
     <loc>https://ideastud.io/fr/services/consultant-dotnet-azure</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/consultant-dotnet-azure" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/dotnet-azure-consulting" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/consultant-dotnet-azure" />
@@ -53,7 +53,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/services/dotnet-azure-consulting</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/consultant-dotnet-azure" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/dotnet-azure-consulting" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/consultant-dotnet-azure" />
@@ -64,7 +64,7 @@
   <!-- Services: Techlead -->
   <url>
     <loc>https://ideastud.io/fr/services/techlead</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/techlead" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/tech-lead" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/techlead" />
@@ -73,7 +73,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/services/tech-lead</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/techlead" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/tech-lead" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/techlead" />
@@ -84,7 +84,7 @@
   <!-- Services: Formateur / Trainer -->
   <url>
     <loc>https://ideastud.io/fr/services/formateur</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/formateur" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/trainer" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/formateur" />
@@ -93,7 +93,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/services/trainer</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/formateur" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/trainer" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/formateur" />
@@ -104,7 +104,7 @@
   <!-- Services: Vibe coding -->
   <url>
     <loc>https://ideastud.io/fr/services/vibe-coding</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/vibe-coding" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/vibe-coding" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/vibe-coding" />
@@ -113,7 +113,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/services/vibe-coding</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/vibe-coding" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/vibe-coding" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/vibe-coding" />
@@ -124,7 +124,7 @@
   <!-- Services: IA en entreprise / AI for the enterprise -->
   <url>
     <loc>https://ideastud.io/fr/services/ia-en-entreprise</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/ia-en-entreprise" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/ai-enterprise" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/ia-en-entreprise" />
@@ -133,7 +133,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/services/ai-enterprise</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/ia-en-entreprise" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/ai-enterprise" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/ia-en-entreprise" />
@@ -144,7 +144,7 @@
   <!-- Services: Applications mobiles / Mobile apps -->
   <url>
     <loc>https://ideastud.io/fr/services/applications-mobiles</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/applications-mobiles" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/mobile-apps" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/applications-mobiles" />
@@ -153,7 +153,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/services/mobile-apps</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/applications-mobiles" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/mobile-apps" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/applications-mobiles" />
@@ -164,7 +164,7 @@
   <!-- Services: Sites internet / Websites -->
   <url>
     <loc>https://ideastud.io/fr/services/sites-internet</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/sites-internet" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/websites" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/sites-internet" />
@@ -173,7 +173,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/services/websites</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/services/sites-internet" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/services/websites" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/services/sites-internet" />
@@ -184,7 +184,7 @@
   <!-- Realisations / Projects -->
   <url>
     <loc>https://ideastud.io/fr/realisations</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/realisations" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/projects" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/realisations" />
@@ -193,7 +193,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/projects</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/realisations" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/projects" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/realisations" />
@@ -204,7 +204,7 @@
   <!-- Case studies -->
   <url>
     <loc>https://ideastud.io/fr/realisations/ardoise-it</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/realisations/ardoise-it" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/projects/ardoise-it" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/realisations/ardoise-it" />
@@ -213,7 +213,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/projects/ardoise-it</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/realisations/ardoise-it" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/projects/ardoise-it" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/realisations/ardoise-it" />
@@ -222,7 +222,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/realisations/dpelib</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/realisations/dpelib" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/projects/dpelib" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/realisations/dpelib" />
@@ -231,7 +231,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/projects/dpelib</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/realisations/dpelib" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/projects/dpelib" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/realisations/dpelib" />
@@ -240,7 +240,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/realisations/brasageneva</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/realisations/brasageneva" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/projects/brasageneva" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/realisations/brasageneva" />
@@ -249,7 +249,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/projects/brasageneva</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/realisations/brasageneva" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/projects/brasageneva" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/realisations/brasageneva" />
@@ -260,7 +260,7 @@
   <!-- CV / Resume -->
   <url>
     <loc>https://ideastud.io/fr/cv</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/cv" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/resume" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/cv" />
@@ -269,7 +269,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/resume</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/cv" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/resume" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/cv" />
@@ -280,7 +280,7 @@
   <!-- About / À propos -->
   <url>
     <loc>https://ideastud.io/fr/a-propos</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/a-propos" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/about" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/a-propos" />
@@ -289,7 +289,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/about</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/a-propos" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/about" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/a-propos" />
@@ -300,7 +300,7 @@
   <!-- FAQ -->
   <url>
     <loc>https://ideastud.io/fr/faq</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/faq" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/faq" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/faq" />
@@ -309,7 +309,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/faq</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/faq" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/faq" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/faq" />
@@ -320,7 +320,7 @@
   <!-- Contact -->
   <url>
     <loc>https://ideastud.io/fr/contact</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/contact" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/contact" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/contact" />
@@ -329,7 +329,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/contact</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/contact" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/contact" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/contact" />
@@ -340,7 +340,7 @@
   <!-- Blog -->
   <url>
     <loc>https://ideastud.io/fr/blog</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/blog" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/blog" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/blog" />
@@ -349,7 +349,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/blog</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/blog" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/blog" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/blog" />
@@ -358,7 +358,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/blog/coder-avec-ia-sans-dette-technique</loc>
-    <lastmod>2026-06-20</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/blog/coder-avec-ia-sans-dette-technique" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/blog/coder-avec-ia-sans-dette-technique" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/blog/coder-avec-ia-sans-dette-technique" />
@@ -367,7 +367,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/blog/coder-avec-ia-sans-dette-technique</loc>
-    <lastmod>2026-06-20</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/blog/coder-avec-ia-sans-dette-technique" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/blog/coder-avec-ia-sans-dette-technique" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/blog/coder-avec-ia-sans-dette-technique" />
@@ -376,7 +376,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/blog/cloud-souverain-europe</loc>
-    <lastmod>2026-06-10</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/blog/cloud-souverain-europe" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/blog/cloud-souverain-europe" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/blog/cloud-souverain-europe" />
@@ -385,7 +385,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/blog/cloud-souverain-europe</loc>
-    <lastmod>2026-06-10</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/blog/cloud-souverain-europe" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/blog/cloud-souverain-europe" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/blog/cloud-souverain-europe" />
@@ -396,7 +396,7 @@
   <!-- Legal -->
   <url>
     <loc>https://ideastud.io/fr/mentions-legales</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/mentions-legales" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/legal" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/mentions-legales" />
@@ -405,7 +405,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/legal</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/mentions-legales" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/legal" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/mentions-legales" />
@@ -416,7 +416,7 @@
   <!-- Privacy -->
   <url>
     <loc>https://ideastud.io/fr/confidentialite</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/confidentialite" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/privacy" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/confidentialite" />
@@ -425,7 +425,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/privacy</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/confidentialite" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/privacy" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/confidentialite" />
@@ -435,7 +435,7 @@
   <!-- Training -->
   <url>
     <loc>https://ideastud.io/fr/formations</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations" />
@@ -444,7 +444,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations" />
@@ -453,7 +453,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/csharp-modern</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/csharp-modern" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/csharp-modern" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/csharp-modern" />
@@ -462,7 +462,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/csharp-modern</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/csharp-modern" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/csharp-modern" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/csharp-modern" />
@@ -471,7 +471,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/aspnet-core-fundamentals</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/aspnet-core-fundamentals" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/aspnet-core-fundamentals" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/aspnet-core-fundamentals" />
@@ -480,7 +480,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/aspnet-core-fundamentals</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/aspnet-core-fundamentals" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/aspnet-core-fundamentals" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/aspnet-core-fundamentals" />
@@ -489,7 +489,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/aspnet-core-advanced</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/aspnet-core-advanced" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/aspnet-core-advanced" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/aspnet-core-advanced" />
@@ -498,7 +498,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/aspnet-core-advanced</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/aspnet-core-advanced" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/aspnet-core-advanced" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/aspnet-core-advanced" />
@@ -507,7 +507,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/blazor-modern</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/blazor-modern" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/blazor-modern" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/blazor-modern" />
@@ -516,7 +516,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/blazor-modern</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/blazor-modern" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/blazor-modern" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/blazor-modern" />
@@ -525,7 +525,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/ef-core-10</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/ef-core-10" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/ef-core-10" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/ef-core-10" />
@@ -534,7 +534,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/ef-core-10</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/ef-core-10" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/ef-core-10" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/ef-core-10" />
@@ -543,7 +543,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/dotnet-testing</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/dotnet-testing" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/dotnet-testing" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/dotnet-testing" />
@@ -552,7 +552,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/dotnet-testing</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/dotnet-testing" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/dotnet-testing" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/dotnet-testing" />
@@ -561,7 +561,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/azure-az204-prep</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-az204-prep" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-az204-prep" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-az204-prep" />
@@ -570,7 +570,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/azure-az204-prep</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-az204-prep" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-az204-prep" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-az204-prep" />
@@ -579,7 +579,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/azure-az400-prep</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-az400-prep" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-az400-prep" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-az400-prep" />
@@ -588,7 +588,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/azure-az400-prep</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-az400-prep" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-az400-prep" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-az400-prep" />
@@ -597,7 +597,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/azure-functions-events</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-functions-events" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-functions-events" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-functions-events" />
@@ -606,7 +606,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/azure-functions-events</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-functions-events" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-functions-events" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-functions-events" />
@@ -615,7 +615,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/azure-app-service-containers</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-app-service-containers" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-app-service-containers" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-app-service-containers" />
@@ -624,7 +624,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/azure-app-service-containers</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-app-service-containers" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-app-service-containers" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-app-service-containers" />
@@ -633,7 +633,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/azure-security-fundamentals</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-security-fundamentals" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-security-fundamentals" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-security-fundamentals" />
@@ -642,7 +642,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/azure-security-fundamentals</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/azure-security-fundamentals" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/azure-security-fundamentals" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/azure-security-fundamentals" />
@@ -651,7 +651,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/claude-code-team</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/claude-code-team" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/claude-code-team" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/claude-code-team" />
@@ -660,7 +660,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/claude-code-team</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/claude-code-team" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/claude-code-team" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/claude-code-team" />
@@ -669,7 +669,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/copilot-advanced</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/copilot-advanced" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/copilot-advanced" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/copilot-advanced" />
@@ -678,7 +678,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/copilot-advanced</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/copilot-advanced" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/copilot-advanced" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/copilot-advanced" />
@@ -687,7 +687,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/mcp-server-design</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/mcp-server-design" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/mcp-server-design" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/mcp-server-design" />
@@ -696,7 +696,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/mcp-server-design</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/mcp-server-design" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/mcp-server-design" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/mcp-server-design" />
@@ -705,7 +705,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/ai-on-premise</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/ai-on-premise" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/ai-on-premise" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/ai-on-premise" />
@@ -714,7 +714,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/ai-on-premise</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/ai-on-premise" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/ai-on-premise" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/ai-on-premise" />
@@ -723,7 +723,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/clean-architecture-dotnet</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/clean-architecture-dotnet" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/clean-architecture-dotnet" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/clean-architecture-dotnet" />
@@ -732,7 +732,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/clean-architecture-dotnet</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/clean-architecture-dotnet" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/clean-architecture-dotnet" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/clean-architecture-dotnet" />
@@ -741,7 +741,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/event-driven-cqrs</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/event-driven-cqrs" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/event-driven-cqrs" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/event-driven-cqrs" />
@@ -750,7 +750,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/event-driven-cqrs</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/event-driven-cqrs" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/event-driven-cqrs" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/event-driven-cqrs" />
@@ -759,7 +759,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/observability-otel</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/observability-otel" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/observability-otel" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/observability-otel" />
@@ -768,7 +768,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/observability-otel</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/observability-otel" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/observability-otel" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/observability-otel" />
@@ -777,7 +777,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/dotnet-performance</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/dotnet-performance" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/dotnet-performance" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/dotnet-performance" />
@@ -786,7 +786,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/dotnet-performance</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/dotnet-performance" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/dotnet-performance" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/dotnet-performance" />
@@ -795,7 +795,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/fr/formations/cicd-github-actions</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/cicd-github-actions" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/cicd-github-actions" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/cicd-github-actions" />
@@ -804,7 +804,7 @@
   </url>
   <url>
     <loc>https://ideastud.io/en/training/cicd-github-actions</loc>
-    <lastmod>2026-06-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://ideastud.io/fr/formations/cicd-github-actions" />
     <xhtml:link rel="alternate" hreflang="en" href="https://ideastud.io/en/training/cicd-github-actions" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://ideastud.io/fr/formations/cicd-github-actions" />


### PR DESCRIPTION
Third increment from the full-site audit. SEO & content coherence. Disjoint from Waves 1–2 (PRs #76, #77).

## C1 · Training day-rate was inconsistent
`Home` + service JSON said **600–800 €**, but `Faq.razor`, `llms.txt` and `ai.txt` said a flat **from 800 €**. Unified every surface on the **600–800 € band** (per owner decision):
- `Faq.razor` (FR/EN): band phrasing across consulting/tech-lead/training/enterprise-AI.
- `llms.txt`: single `600–800 € / day` line.
- `ai.txt`: `dayRateConsulting`/`dayRateTraining` → `dayRateMin`/`dayRateMax`.

## C2 · Twitter attribution was never emitted
`SeoHead` supported `TwitterSite`/`TwitterCreator` but no page passed them. Home now emits `@imcresus_` (escaped `@@` in Razor).

## C3 · Stale sitemap dates
`sitemap.xml` `lastmod` was 2026-06-24/25 while content changed later. Refreshed all 86 entries to 2026-07-26. `feed.xml` `pubDate`s are genuine publication dates — left as-is (the thin-blog point is content, not a date bug).

## C4 · OG image had no declared dimensions
Added `OgImageType`/`OgImageWidth`/`OgImageHeight` to `SeoHead`; Home declares the real 800×800 `image/jpeg` for predictable LinkedIn/X/Slack card rendering.

Also strips a stray UTF-8 BOM from `ai.txt` (same one-line fix as Wave 1; merges cleanly).

## Verification
- `dotnet build` clean (0 warnings), **170 tests** green.
- `ai.txt` valid JSON; `sitemap.xml` valid XML (86 URLs).